### PR TITLE
Added support for typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /chrome
 /tests/**/*.js
 /tests/**/*.map
+/docs/*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,11 +13,12 @@ var gutil = require("gulp-util");
 var rename = require("gulp-rename");
 var ts = require("gulp-typescript");
 var tslint = require("gulp-tslint");
+var typedoc = require("gulp-typedoc");
 
 // Other Modules
 var runSequence = require("run-sequence");
 var bower = require("bower");
-var sh = require("shelljs")
+var sh = require("shelljs");
 var async = require("async");
 var xpath = require("xpath");
 var XmlDom = require("xmldom").DOMParser;
@@ -539,4 +540,27 @@ gulp.task("git-check", function(done) {
     }
 
     done();
+});
+
+/**
+ * An gulp task to create documentation for typescript.
+ */
+gulp.task("typedoc", function() {
+    return gulp
+        .src(paths.ts)
+        .pipe(typedoc({
+            module: "commonjs",
+            target: "es5",
+            out: "docs/",
+            name: "Ionic TypeScript Starter"
+        }));
+});
+
+/**
+ * Removes the docs directory.
+ */
+gulp.task("clean:typedoc", function (cb) {
+    del([
+        "docs"
+    ], cb);
 });

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
   "cordovaPlatforms": [
     "android",
     "ios"
-  ]
+  ],
+  "devDependencies": {
+    "gulp-typedoc": "^1.2.1",
+    "typedoc": "^0.3.8"
+  }
 }


### PR DESCRIPTION
It now can be invoked with 'gulp typedoc' and 'gulp clean:typedoc'.

This is my first pull-request ever, so please let me know if I am missing something. I did not want to add this to gulp default and run the risk of breaking something. if you please, you may add it later.

Let me know if you need anything to be modified for this one.