### PR TITLE
Fix failing package-web, package-chorme gulp tasks

### DIFF
--- a/resources/build/tasks/config.js
+++ b/resources/build/tasks/config.js
@@ -43,7 +43,7 @@ module.exports = function(gulp, plugins) {
             // Chrome Extension: --prep chrome
 
             helper.info(helper.format("Generating: build/chrome/manifest.json from: resources/chrome/manifest.master.json"));
-            sh.mkdir("build/chrome");
+            sh.mkdir("-p", "build/chrome");
             helper.performVariableReplacement(schemeName, "resources/chrome/manifest.master.json", "build/chrome/manifest.json");
 
             helper.info(helper.format("Generating: www/index.html from resources/chrome/index.master.html"));

--- a/resources/build/tasks/package-chrome.js
+++ b/resources/build/tasks/package-chrome.js
@@ -27,6 +27,9 @@ module.exports = function(gulp, plugins) {
         sh.rm("-rf", "build/chrome");
         sh.rm("-rf", "build/chrome.tar.gz");
 
+        // Ensure the target directory exists.
+        sh.mkdir("-p", "build/chrome");
+
         // Delegate to the config task to generate the index, manifest, and build vars.
         runSequence("config", function (err) {
 
@@ -37,7 +40,7 @@ module.exports = function(gulp, plugins) {
 
             // Copy the www payload.
             helper.info("Copying www to build/chrome");
-            sh.cp("-R", "www", "build/chrome");
+            sh.cp("-R", "www/", "build/chrome");
 
             // Copy the icon.
             helper.info("Copying resources/icon.png to build/chrome/icon.png");

--- a/resources/build/tasks/package-web.js
+++ b/resources/build/tasks/package-web.js
@@ -31,6 +31,9 @@ module.exports = function(gulp, plugins) {
         sh.rm("-rf", "build/web");
         sh.rm("-rf", "build/web.tar.gz");
 
+        // Ensure the target directory exists.
+        sh.mkdir("-p", "build/web");
+
         // Delegate to the config task to generate the index, manifest, and build vars.
         runSequence("config", function (err) {
 
@@ -40,7 +43,7 @@ module.exports = function(gulp, plugins) {
             }
 
             helper.info("Copying www to build/web");
-            sh.cp("-R", "www", "build/web");
+            sh.cp("-R", "www/", "build/web");
 
             helper.info("Bundling css, lib, and js directories to build/web/resources-temp");
             sh.mkdir("-p", "build/web/resources-temp");


### PR DESCRIPTION
* Ensures that the `build/chrome` directory full path is created even when `build` does not exist yet
* Ensures that `build/chrome` and `build/web` exist when packaging instead of relying on `cp` to create them
* Modified `cp` in the package tasks to copy the _contents_ of the `www` directory (rather than the directory itself) into `build/chrome` and `build/web`

Resolves #65 