### PR TITLE
JS and lib bundles no longer block rendering for web builds

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -157,7 +157,7 @@ namespace JustinCredible.SampleApp {
                 }
 
                 // If the user is still at the blank sreen, then push them to their default view.
-                if (this.$location.url() === "/app/blank") {
+                if (this.$location.url() === "" || this.$location.url() === "/app/blank") {
 
                     // Tell Ionic to not animate and clear the history (hide the back button)
                     // for the next view that we'll be navigating to below.


### PR DESCRIPTION
resolves #76 

This changes the `<script>` tags for the JavaScript bundles to be inserted programmatically on `window.onload` with their `async=false` properties set. This ensures that the `index.html` page will be parsed and fully rendered so it's loading spinner can be shown while the JS bundles are downloaded.

This is only applicable to web builds via `gulp package-web`.