### PR TITLE
Added Ionic type definitions

### DIFF
--- a/docs/base-framework.md
+++ b/docs/base-framework.md
@@ -85,7 +85,7 @@ namespace JustinCredible.SampleApp.Controllers {
 
         //#region BaseController Events
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             // Set the category number into the view model using the value as provided
@@ -352,7 +352,7 @@ Although this starter project does not contain a specific base class for Ionic's
 A popover is generally initialized via the `view_beforeEnter` event by specifying the path to an HTML template and the scope to use (which can be the same scope as the current controller). The popover can later be shown by invoking its `show()` method:
 
 ```
-protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
     super.view_beforeEnter(event, eventArgs);
 
     this.$ionicPopover.fromTemplateUrl("Views/Settings/Logs-List/Log-Filter-Menu.html", {

--- a/resources/build/tasks/lint.js
+++ b/resources/build/tasks/lint.js
@@ -16,7 +16,10 @@ module.exports = function(gulp, plugins) {
             "./src/**/*.ts",
             "./tests/**/*.ts",
             "./typings/custom/**/*.d.ts",
-            "./typings-tests/custom/**/*.d.ts"
+            "./typings-tests/custom/**/*.d.ts",
+
+            // Ignore: This was written by a third party and does not match our lint rules.
+            "!./typings/custom/ionic.d.ts",
         ];
 
         return gulp.src(filesToLint)

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -26,7 +26,7 @@ namespace JustinCredible.SampleApp {
             private $rootScope: ng.IRootScopeService,
             private $window: ng.IWindowService,
             private $location: ng.ILocationService,
-            private $ionicHistory: any,
+            private $ionicHistory: ionic.navigation.IonicHistoryService,
             private Plugins: Services.Plugins,
             private Utilities: Services.Utilities,
             private Compatibility: Services.Compatibility,

--- a/src/Framework/BaseController.ts
+++ b/src/Framework/BaseController.ts
@@ -53,7 +53,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_loaded(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_loaded(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -66,7 +66,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_enter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_enter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -79,7 +79,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_leave(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_leave(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -92,7 +92,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -105,7 +105,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_beforeLeave(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeLeave(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -118,7 +118,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_afterEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_afterEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -131,7 +131,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_afterLeave(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_afterLeave(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 
@@ -144,7 +144,7 @@
          * 
          * Can be overridden by implementing controllers.
          */
-        protected view_unloaded(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_unloaded(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             /* tslint:disable:no-empty */
             /* tslint:enable:no-empty */
 

--- a/src/Framework/Boot2.ts
+++ b/src/Framework/Boot2.ts
@@ -103,7 +103,7 @@ namespace JustinCredible.SampleApp.Boot2 {
      * dependency injection based on the name of each parameter.
      */
     function angular_initialize(
-        $ionicPlatform: Ionic.IPlatform,
+        $ionicPlatform: ionic.platform.IonicPlatformService,
         Application: Application,
         Configuration: Services.Configuration,
         MockHttpApis: Services.MockHttpApis
@@ -133,7 +133,7 @@ namespace JustinCredible.SampleApp.Boot2 {
         $provide: ng.auto.IProvideService,
         $httpProvider: ng.IHttpProvider,
         $compileProvider: ng.ICompileProvider,
-        $ionicConfigProvider: any
+        $ionicConfigProvider: ionic.utility.IonicConfigProvider
         ): void {
 
         // Intercept the default Angular exception handler.

--- a/src/Services/MockPlatformApis.ts
+++ b/src/Services/MockPlatformApis.ts
@@ -20,8 +20,8 @@
 
         constructor(
             private $q: ng.IQService,
-            private $ionicPopup: any,
-            private $ionicLoading: any,
+            private $ionicPopup: ionic.popup.IonicPopupService,
+            private $ionicLoading: ionic.loading.IonicLoadingService,
             private Utilities: Utilities) {
         }
 

--- a/src/Services/UiHelper.ts
+++ b/src/Services/UiHelper.ts
@@ -25,8 +25,8 @@
         constructor(
             private $window: Window,
             private $q: ng.IQService,
-            private $ionicModal: any,
-            private $ionicSideMenuDelegate: any,
+            private $ionicModal: ionic.modal.IonicModalService,
+            private $ionicSideMenuDelegate: ionic.sideMenu.IonicSideMenuDelegate,
             private Plugins: Plugins,
             private Logger: Logger,
             private Preferences: Preferences,
@@ -471,7 +471,10 @@
                 this._sideMenuMediaQuery = this._sideMenuMediaQueryNeverVisible;
             }
 
-            this.$ionicSideMenuDelegate._instances[0].exposeAside(this.$window.matchMedia(this._sideMenuMediaQuery).matches);
+            /* tslint:disable:no-string-literal */
+            this.$ionicSideMenuDelegate["_instances"][0].exposeAside(this.$window.matchMedia(this._sideMenuMediaQuery).matches);
+            /* tslint:enable:no-string-literal */
+
             this.$ionicSideMenuDelegate.canDragContent(allow);
         }
 

--- a/src/Views/Category/CategoryController.ts
+++ b/src/Views/Category/CategoryController.ts
@@ -27,7 +27,7 @@
 
         //#region BaseController Events
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             // Set the category number into the view model using the value as provided

--- a/src/Views/Onboarding/Onboarding-Register/OnboardingRegisterController.ts
+++ b/src/Views/Onboarding/Onboarding-Register/OnboardingRegisterController.ts
@@ -21,7 +21,7 @@ namespace JustinCredible.SampleApp.Controllers {
         constructor(
             $scope: ng.IScope,
             private $location: ng.ILocationService,
-            private $ionicHistory: any,
+            private $ionicHistory: ionic.navigation.IonicHistoryService,
             private Plugins: Services.Plugins,
             private Utilities: Services.Utilities,
             private UiHelper: Services.UiHelper,
@@ -33,7 +33,7 @@ namespace JustinCredible.SampleApp.Controllers {
 
         //#region BaseController Events
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.viewModel.showSignIn = false;

--- a/src/Views/Onboarding/Onboarding-Share/OnboardingShareController.ts
+++ b/src/Views/Onboarding/Onboarding-Share/OnboardingShareController.ts
@@ -21,7 +21,7 @@ namespace JustinCredible.SampleApp.Controllers {
         constructor(
             $scope: ng.IScope,
             private $location: ng.ILocationService,
-            private $ionicHistory: any,
+            private $ionicHistory: ionic.navigation.IonicHistoryService,
             private Utilities: Services.Utilities,
             private UiHelper: Services.UiHelper,
             private Plugins: Services.Plugins,

--- a/src/Views/Onboarding/Onboarding-Splash/OnboardingSplashController.ts
+++ b/src/Views/Onboarding/Onboarding-Splash/OnboardingSplashController.ts
@@ -20,7 +20,7 @@ namespace JustinCredible.SampleApp.Controllers {
         constructor(
             $scope: ng.IScope,
             private $location: ng.ILocationService,
-            private $ionicHistory: any,
+            private $ionicHistory: ionic.navigation.IonicHistoryService,
             private Utilities: Services.Utilities,
             private UiHelper: Services.UiHelper,
             private Configuration: Services.Configuration) {
@@ -31,7 +31,7 @@ namespace JustinCredible.SampleApp.Controllers {
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             // During onboarding the menu shouldn't be visible.

--- a/src/Views/Root/RootController.ts
+++ b/src/Views/Root/RootController.ts
@@ -35,7 +35,7 @@
 
         //#region BaseController Overrides
 
-        protected view_loaded(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_loaded(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_loaded(event, eventArgs);
 
             // In most cases Ionic's load event only fires once, the first time the controller is

--- a/src/Views/Settings/About/AboutController.ts
+++ b/src/Views/Settings/About/AboutController.ts
@@ -18,7 +18,7 @@
 
         constructor(
             $scope: ng.IScope,
-            private $ionicHistory: any,
+            private $ionicHistory: ionic.navigation.IonicHistoryService,
             private Utilities: Services.Utilities,
             private Configuration: Services.Configuration,
             private Plugins: Services.Plugins) {
@@ -29,7 +29,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.viewModel.logoClickCount = 0;

--- a/src/Views/Settings/Cloud-Sync/CloudSyncController.ts
+++ b/src/Views/Settings/Cloud-Sync/CloudSyncController.ts
@@ -15,7 +15,7 @@
 
         constructor(
             $scope: ng.IScope,
-            private $ionicHistory: any) {
+            private $ionicHistory: ionic.navigation.IonicHistoryService) {
             super($scope, ViewModels.CloudSyncViewModel);
 
             this.scope.$on("icon-panel.cloud-icon-panel.created", _.bind(this.iconPanel_created, this));
@@ -28,7 +28,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             // Setup the view model.
@@ -38,7 +38,7 @@
             this.viewModel.userCount = 2344;
         }
 
-        protected view_leave(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_leave(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_leave(event, eventArgs);
 
             // Stop the toggleIcon function from firing.

--- a/src/Views/Settings/Configure-Pin/ConfigurePinController.ts
+++ b/src/Views/Settings/Configure-Pin/ConfigurePinController.ts
@@ -27,7 +27,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.viewModel.isPinSet = this.Preferences.pin !== null;

--- a/src/Views/Settings/Developer/DeveloperController.ts
+++ b/src/Views/Settings/Developer/DeveloperController.ts
@@ -43,7 +43,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.viewModel.mockApiRequests = this.Configuration.enableMockHttpCalls;

--- a/src/Views/Settings/Log-Entry/LogEntryController.ts
+++ b/src/Views/Settings/Log-Entry/LogEntryController.ts
@@ -34,7 +34,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.viewModel.logEntry = this.Logger.getLog(this.$stateParams.id);

--- a/src/Views/Settings/Logs-List/LogsListController.ts
+++ b/src/Views/Settings/Logs-List/LogsListController.ts
@@ -17,7 +17,7 @@
 
         constructor(
             $scope: ng.IScope,
-            private $ionicPopover: any,
+            private $ionicPopover: ionic.popover.IonicPopoverService,
             private Logger: Services.Logger,
             private UiHelper: Services.UiHelper) {
             super($scope, ViewModels.LogsListViewModel);
@@ -29,7 +29,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.$ionicPopover.fromTemplateUrl("Views/Settings/Logs-List/Log-Filter-Menu.html", {

--- a/src/Views/Settings/Settings-List/SettingsListController.ts
+++ b/src/Views/Settings/Settings-List/SettingsListController.ts
@@ -25,7 +25,7 @@
 
         //#region BaseController Overrides
 
-        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: Ionic.IViewEventArguments): void {
+        protected view_beforeEnter(event?: ng.IAngularEvent, eventArgs?: IonicExtras.IViewEventArguments): void {
             super.view_beforeEnter(event, eventArgs);
 
             this.viewModel.isDebugMode = this.Utilities.isDebugMode;

--- a/typings/custom/IonicExtras.d.ts
+++ b/typings/custom/IonicExtras.d.ts
@@ -1,0 +1,33 @@
+
+declare module IonicExtras {
+
+    /**
+     * Describes the event arguments passed to $ionicView events.
+     */
+    interface IViewEventArguments {
+        viewId: string;
+        historyId: string;
+        stateId: string;
+        stateName: string;
+        stateParams: {
+            id: string;
+            parent: string;
+        };
+        transition: string;
+        navBarTransition: string;
+        direction: string;
+        shouldAnimate: boolean;
+        transitionId: number;
+        fromCache: boolean;
+        enableBack: boolean;
+        renderStart: boolean;
+        renderEnd: boolean;
+        viewNotified: boolean;
+        title: string;
+        showBack: boolean;
+        navBarItems: any;
+        navBarDelegate: any;
+        showNavBar: boolean;
+        hasHeaderBar: boolean;
+    }
+}

--- a/typings/custom/ionic.d.ts
+++ b/typings/custom/ionic.d.ts
@@ -1,134 +1,401 @@
-﻿
-/**
- * This file contains Ionic specific APIs that do not yet have typings in the
- * DefinitelyTyped repository.
- */
-declare module Ionic {
 
+// Taken from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ae4fe7b6dec1fbbee9a2b454e7cc389b3bd2fd35/ionic/index.d.ts
+// and modified to make the reference tag compatible with TypeScript 1.6.x.
+
+// Type definitions for Ionic
+// Project: http://ionicframework.com
+// Definitions by: Spencer Williams <https://github.com/spencerwi/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+
+interface IonicStatic {
     /**
-     * Describes the Ionic Platform object.
-     * 
-     * http://ionicframework.com/docs/api/utility/ionic.Platform/
+     * What Ionic package version is.
      */
-    interface IPlatform {
-
+    version: string;
+    Platform: {
         /**
-         * Whether the device is ready
+        * Trigger a callback once the device is ready, or immediately
+         * if the device is already ready. This method can be run from
+         * anywhere and does not need to be wrapped by any additonal methods.
+         * When the app is within a WebView (Cordova), it’ll fire
+         * the callback once the device is ready. If the app is within
+         * a web browser, it’ll fire the callback after window.load.
+         * Please remember that Cordova features (Camera, FileSystem, etc) still
+         * will not work in a web browser.
          */
-        isReady: boolean;
-
+        ready(callback: ()=>any): void;
         /**
-         * Whether the device is full screen.
+         * Set the grade of the device: ‘a’, ‘b’, or ‘c’. ‘a’ is the best
+         * (most css features enabled), ‘c’ is the worst. By default, sets the grade
+         * depending on the current device.
          */
-        isFullScreen: boolean;
-
+        setGrade(grade: string): void;
         /**
-         * An array of all platforms found.
+         * Return the current device (given by cordova).
          */
-        platforms: string[];
-
+        device(): any;
         /**
-         * What grade the current platform is.
+         * Check if the platform name provided is detected.
          */
-        grade: string;
-
-        /**
-         * Trigger a callback once the device is ready, or immediately if the device is already ready.
-         * This method can be run from anywhere and does not need to be wrapped by any additional methods.
-         * When the app is within a WebView (Cordova), it'll fire the callback once the device is ready.
-         * If the app is within a web browser, it'll fire the callback after window.load.
-         */
-        ready(callback: () => void): void;
-
-        /**
-         * Set the grade of the device: 'a', 'b', or 'c'. 'a' is the best (most css features enabled),
-         * 'c' is the worst. By default, sets the grade depending on the current device.
-         */
-        setGrade(grade): void;
-
+        is(platformName: string): boolean;
         /**
          * Check if we are running within a WebView (such as Cordova).
          */
         isWebView(): boolean;
-
         /**
          * Whether we are running on iPad.
          */
         isIPad(): boolean;
-
         /**
          * Whether we are running on iOS.
          */
         isIOS(): boolean;
-
         /**
-         * Whether we are running on Android
+         * Whether we are running on Android.
          */
         isAndroid(): boolean;
-
         /**
          * Whether we are running on Windows Phone.
          */
         isWindowsPhone(): boolean;
-
         /**
          * The name of the current platform.
          */
         platform(): string;
-
         /**
          * The version of the current device platform.
          */
-        version(): string;
-
+        version(): number;
         /**
-         * Exit the application.
+         * Exit the app.
          */
         exitApp(): void;
-
         /**
-         * Shows or hides the device status bar (in Cordova).
-         * 
-         * @param showShould Whether or not to show the status bar.
+         * Shows or hides the device status bar (in Cordova). Requires cordova plugin add org.apache.cordova.statusbar
          */
         showStatusBar(shouldShow: boolean): void;
-
         /**
-         * Sets whether the app is full screen or not (in Cordova).
-         * 
-         * @param showFullScreen Whether or not to set the app to full screen. Defaults to true.
-         * @param showStatusBar Whether or not to show the device's status bar. Defaults to false.
+         * Sets whether the app is fullscreen or not (in Cordova).
          */
-        fullScreen(showFullScreen: boolean, showStatusBar: boolean): void;
-    }
+        fullScreen(showFullScreen?: boolean, showStatusBar?: boolean): void;
+        /**
+         * Whether the device is ready.
+         */
+        isReady: boolean;
+        /**
+         * Whether the device is fullscreen.
+         */
+        isFullScreen: boolean;
+        /**
+         * An array of all platforms found.
+         */
+        platforms: Array<string>;
+        /**
+         * What grade the current platform is.
+         */
+        grade: string;
+    };
+}
 
-    /**
-     * Describes the event arguments passed to $ionicView events.
-     */
-    interface IViewEventArguments {
-        viewId: string;
-        historyId: string;
-        stateId: string;
-        stateName: string;
-        stateParams: {
-            id: string;
-            parent: string;
-        };
-        transition: string;
-        navBarTransition: string;
-        direction: string;
-        shouldAnimate: boolean;
-        transitionId: number;
-        fromCache: boolean;
-        enableBack: boolean;
-        renderStart: boolean;
-        renderEnd: boolean;
-        viewNotified: boolean;
-        title: string;
-        showBack: boolean;
-        navBarItems: any;
-        navBarDelegate: any;
-        showNavBar: boolean;
-        hasHeaderBar: boolean;
+declare var ionic: IonicStatic;
+
+declare module 'ionic' {
+    export = ionic;
+}
+
+declare namespace ionic {
+    namespace actionSheet {
+        interface IonicActionSheetService {
+            show(options: IonicActionSheetOptions): ()=>void;
+        }
+        interface IonicActionSheetButton {
+            text: string;
+        }
+        interface IonicActionSheetOptions {
+            buttons?: Array<IonicActionSheetButton>;
+            titleText?: string;
+            cancelText?: string;
+            destructiveText?: string;
+            cancel?: ()=>any;
+            buttonClicked?: (index: number)=>boolean;
+            destructiveButtonClicked?: ()=>boolean;
+            cancelOnStateChange?: boolean;
+            cssClass?: string;
+        }
+    }
+    namespace backdrop {
+        interface IonicBackdropService {
+            retain(): void;
+            release(): void;
+        }
+    }
+    namespace gestures {
+        interface IonicGestureService {
+            on(eventType: string, callback: (e: any)=>any, $element: angular.IAugmentedJQuery, options: any): IonicGesture;
+            off(gesture: IonicGesture, eventType: string, callback: (e: any)=>any): void;
+        }
+
+        interface IonicGesture {
+            element: Element;
+            enabled: boolean;
+            options: {stop_browser_behavior: string };
+            on(gesture: string, handler: Function): IonicGesture;
+            off(gesture: string, handler: Function): IonicGesture;
+            trigger(gesture: string, eventData: any): IonicGesture;
+            enable(state: boolean): IonicGesture;
+        }
+
+    }
+    namespace list {
+        interface IonicListDelegate {
+            showReorder(showReorder?: boolean): boolean;
+            showDelete(showDelete?: boolean): boolean;
+            canSwipeItems(canSwipeItems?: boolean): boolean;
+            closeOptionButtons(): void;
+            $getByHandle(handle: string): IonicListDelegate;
+        }
+    }
+    namespace loading {
+        interface IonicLoadingService {
+            show(opts?: IonicLoadingOptions): void;
+            hide(): void;
+        }
+        interface IonicLoadingOptions {
+            template?: string;
+            templateUrl?: string;
+            scope?: any;
+            noBackdrop?: boolean;
+            hideOnStateChange?: boolean;
+            delay?: number;
+            duration?: number;
+        }
+    }
+    namespace modal {
+        interface IonicModalService {
+            fromTemplate(templateString: string, options?: IonicModalOptions): IonicModalController;
+            fromTemplateUrl(templateUrl: string, options?: IonicModalOptions): angular.IPromise<IonicModalController>;
+        }
+
+        interface IonicModalController {
+            initialize(options: IonicModalOptions): void;
+            show(): angular.IPromise<void>;
+            hide(): angular.IPromise<void>;
+            remove(): angular.IPromise<void>;
+            isShown(): boolean;
+        }
+
+        interface IonicModalOptions {
+            scope?: any;
+            animation?: string;
+            focusFirstInput?: boolean;
+            backdropClickToClose?: boolean;
+            hardwareBackButtonClose?: boolean;
+        }
+    }
+    namespace navigation {
+        interface IonicNavBarDelegate {
+            align(direction?: string): void;
+            showBackButton(show?: boolean): boolean;
+            showBar(show?: boolean): boolean;
+            title(title: string): void;
+        }
+
+        interface IonicHistoryService {
+            viewHistory(): any;
+
+            currentView(view?: any): any;
+            currentHistoryId(): string;
+            currentTitle(val?: string): string;
+
+            backView(view?: any): any;
+            backTitle(): string;
+
+            forwardView(view?: any): any;
+
+            currentStateName(): string;
+
+            goBack(backCount?: number): void;
+            removeBackView(): void;
+            clearHistory(): void;
+            clearCache(): angular.IPromise<any>;
+            nextViewOptions(options: IonicHistoryNextViewOptions): void;
+        }
+        interface IonicHistoryNextViewOptions {
+            disableAnimate?: boolean;
+            disableBack?: boolean;
+            historyRoot?: boolean;
+        }
+    }
+    namespace platform {
+        interface IonicPlatformService {
+            onHardwareBackButton(callback: Function): void;
+            offHardwareBackButton(callback: Function): void;
+            registerBackButtonAction(callback: Function, priority: number, actionId?: any): Function;
+            on(type: string, callback: Function): Function;
+            ready(callback?: Function): angular.IPromise<any>;
+        }
+    }
+    namespace popover {
+        interface IonicPopoverService {
+            fromTemplate(templateString: string, options: IonicPopoverOptions): IonicPopoverController;
+            fromTemplateUrl(templateUrl: string, options: IonicPopoverOptions): angular.IPromise<IonicPopoverController>;
+        }
+        interface IonicPopoverController {
+            initialize(options: IonicPopoverOptions): void;
+            show($event?: any): angular.IPromise<any>;
+            hide(): angular.IPromise<any>;
+            isShown(): boolean;
+            remove(): angular.IPromise<any>;
+        }
+        interface IonicPopoverOptions {
+            scope?: any;
+            focusFirstInput?: boolean;
+            backdropClickToClose?: boolean;
+            hardwareBackButtonClose?: boolean;
+        }
+    }
+    namespace popup {
+        interface IonicPopupService {
+            show(options: IonicPopupFullOptions): IonicPopupPromise;
+            alert(options: IonicPopupAlertOptions): IonicPopupPromise;
+            confirm(options: IonicPopupConfirmOptions): IonicPopupConfirmPromise;
+            prompt(options: IonicPopupPromptOptions): IonicPopupPromise;
+        }
+
+        interface IonicPopupConfirmPromise extends angular.IPromise<boolean> {
+            close(value?: boolean): void;
+        }
+        interface IonicPopupPromise extends angular.IPromise<any> {
+            close(value?: any): any;
+        }
+        interface IonicPopupBaseOptions {
+            title?: string;
+            cssClass?: string;
+            subTitle?: string;
+            template?: string;
+            templateUrl?: string;
+        }
+        interface IonicPopupFullOptions extends IonicPopupBaseOptions {
+            scope?: any;
+            buttons?: Array<IonicPopupButton>;
+        }
+        interface IonicPopupButton {
+            text: string;
+            type?: string;
+            onTap?(event?: any): void;
+        }
+        interface IonicPopupAlertOptions extends IonicPopupBaseOptions {
+            okText?: string;
+            okType?: string;
+        }
+        interface IonicPopupConfirmOptions extends IonicPopupBaseOptions {
+            cancelText?: string;
+            cancelType?: string;
+            okText?: string;
+            okType?: string;
+        }
+        interface IonicPopupPromptOptions extends IonicPopupBaseOptions {
+            inputType?: string;
+            inputPlaceholder?: string;
+            cancelText?: string;
+            cancelType?: string;
+            okText?: string;
+            okType?: string;
+        }
+    }
+    namespace scroll {
+        interface IonicScrollDelegate {
+            resize(): void;
+            scrollTop(shouldAnimate?: boolean): void;
+            scrollBottom(shouldAnimate?: boolean): void;
+            scrollTo(left: number, top: number, shouldAnimate?: boolean): void;
+            scrollBy(left: number, top: number, shouldAnimate?: boolean): void;
+            zoomTo(level: number, animate?: boolean, originLeft?: number, originTop?: number): void;
+            zoomBy(factor: number, animate?: boolean, originLeft?: number, originTop?: number): void;
+            getScrollPosition(): {left: number; top: number};
+            anchorScroll(shouldAnimate?: boolean): void;
+            freezeScroll(shouldFreeze?: boolean): boolean;
+            freezeAllScrolls(shouldFreeze?: boolean): boolean;
+            getScrollView(): any;
+            $getByHandle(handle: string): IonicScrollDelegate;
+        }
+    }
+    namespace sideMenu {
+        interface IonicSideMenuDelegate {
+            toggleLeft(isOpen?: boolean): void;
+            toggleRight(isOpen?: boolean): void;
+            getOpenRatio(): number;
+            isOpen(): boolean;
+            isOpenLeft(): boolean;
+            isOpenRight(): boolean;
+            canDragContent(canDrag?: boolean): boolean;
+            edgeDragThreshold(value?: boolean|number): boolean;
+            $getByHandle(handle: string): IonicSideMenuDelegate;
+        }
+    }
+    namespace slideBox {
+        interface IonicSlideBoxDelegate {
+            update(): void;
+            slide(to: number, speed?: number): void;
+            enableSlide(shouldEnable?: boolean): boolean;
+            previous(speed?: number): void;
+            next(speed?: number): void;
+            stop(): void;
+            start(): void;
+            currentIndex(): number;
+            slidesCount(): number;
+            $getByHandle(handle: string): IonicSlideBoxDelegate;
+        }
+    }
+    namespace tabs {
+        interface IonicTabsDelegate {
+            select(index: number): void;
+            selectedIndex(): number;
+            $getByHandle(handle: string): IonicTabsDelegate;
+            showBar(show?: boolean): boolean;
+        }
+    }
+    namespace utility {
+        interface IonicConfigProvider {
+            views: {
+                transition(transition?: string): string;
+                maxCache(maxNumber?: number): number;
+                forwardCache(value?: boolean): boolean;
+                swipeBackEnabled(value?: boolean): boolean;
+            };
+            scrolling: {
+                jsScrolling(value?: boolean): boolean;
+            };
+            backButton: {
+                icon(value?: string): string;
+                text(value?: string): string;
+                previousTitleText(value?: boolean): boolean;
+            };
+            form: {
+                checkbox(value?: string): string;
+                toggle(value?: string): string;
+            };
+            spinner: {
+                icon(value?: string): string;
+            };
+            tabs: {
+                style(value?: string): string;
+                position(value?: string): string;
+            };
+            templates: {
+                maxPrefetch(value?: number): number;
+            };
+            navBar: {
+                alignTitle(value?: string): string;
+                positionPrimaryButtons(value?: string): string;
+                positionSecondaryButtons(value?: string): string;
+            };
+        }
+        interface IonicPositionService {
+            position(element: any): {top: number; left: number; width: number; height: number};
+            offset(element: any): {top: number; left: number; width: number; height: number};
+        }
     }
 }


### PR DESCRIPTION
Resolves #17 

This adds `typings/custom/ionic.d.ts` which was taken from [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ae4fe7b6dec1fbbee9a2b454e7cc389b3bd2fd35/ionic/index.d.ts).

Unfortunately, the TypeScript and DefinitelyTyped ecosystems have changed a bit since this project was created, and the existing set of definitions for Ionic requires a newer version of TypeScript to support the `/// <reference types="angular" />` directive. In order to keep the changes simple for now, I pulled the file into this repo and updated the directive to `/// <reference path="../angularjs/angular.d.ts" />`.

At some point this should be revisited, probably during #63.